### PR TITLE
Typo in config.json : server-ltp of aips-0-0-9-op-c-is-mwdg-1-0-0-500 , aips-0-0-9-op-c-is-mwdg-1-0-0-510 shall be updated to aips-0-0-9-http-c-mwdg-1-0-0-000

### DIFF
--- a/spec/AirInterfacePowerSaver+config.json
+++ b/spec/AirInterfacePowerSaver+config.json
@@ -2117,7 +2117,7 @@
         "client-ltp": [
         ],
         "server-ltp": [
-          "aips-0-0-10-http-c-mwdi-1-1-1-000"
+          "aips-0-0-10-http-c-mwdg-1-1-1-000"
         ],
           "layer-protocol": [
             {
@@ -2142,7 +2142,7 @@
           "client-ltp": [
           ],
           "server-ltp": [
-            "aips-0-0-10-http-c-mwdi-1-1-1-000"
+            "aips-0-0-10-http-c-mwdg-1-1-1-000"
           ],
           "layer-protocol": [
             {


### PR DESCRIPTION
Fixes #118