### PR TITLE
Request to add automation-name in the request-body example for services /v1/switch-redundant-transmitter-pair-off and /v1/reactivate-transmitters-of-link

### DIFF
--- a/spec/AirInterfacePowerSaver.yaml
+++ b/spec/AirInterfacePowerSaver.yaml
@@ -773,6 +773,7 @@ paths:
                   description: 'Operation at the requestor for receiving the response'
               example:
                 link-id: '305551234'
+                automation-name: 'TimeBasedPowerSaving'
                 requestor-protocol: 'HTTP'
                 requestor-address:
                   ip-address:
@@ -1576,6 +1577,7 @@ paths:
                   description: 'Operation at the requestor for receiving the response'
             example:
               link-id: '305551234'
+              automation-name: 'TimeBasedPowerSaving'
               requestor-protocol: 'HTTP'
               requestor-address:
                 ip-address:


### PR DESCRIPTION
Fixes #69